### PR TITLE
Improvement for Statement.create and fix for issue #9

### DIFF
--- a/app/controllers/FeedDaemon.scala
+++ b/app/controllers/FeedDaemon.scala
@@ -53,7 +53,7 @@ object FeedDaemon {
             stmt.id,
             stmt.title,
             removeMarkdownLink(stmt.title + " " + stmt.quote.getOrElse("")),
-            stmt.tags.map(_.name)
+            stmt.tags.map(_.name).toSeq
           )
       }.toSeq
     }

--- a/app/controllers/FeedDaemon.scala
+++ b/app/controllers/FeedDaemon.scala
@@ -53,7 +53,7 @@ object FeedDaemon {
             stmt.id,
             stmt.title,
             removeMarkdownLink(stmt.title + " " + stmt.quote.getOrElse("")),
-            stmt.tags.map(_.name).toSeq
+            stmt.tags.map(_.name)
           )
       }.toSeq
     }

--- a/app/models/Statement.scala
+++ b/app/models/Statement.scala
@@ -171,11 +171,13 @@ object Statement {
 
 	def create(implicit connection: java.sql.Connection, title: String, author: Author, cat: Category, quote: Option[String], quote_src: Option[String], rating: Option[Rating], merged_id: Option[Long]): Statement = {
 
+    if(author.rated) require(rating.isDefined && merged_id.isEmpty)
+
 		require(author.rated || merged_id.isDefined || !rating.isDefined)
 
 		// Get the project id
 		val id: Long = SQL("select nextval('stmt_id_seq')").as(scalar[Long].single)
-		val rated = rating map { r => new Date() };
+		val rated = rating map { r => new Date() }
 		// Insert the project
 		SQL("insert into statement values ({id}, {title}, {author_id}, {cat_id}, {quote}, {quote_src}, {rating}, {rated}, {merged_id})").on(
 				'id -> id,

--- a/app/models/Statement.scala
+++ b/app/models/Statement.scala
@@ -33,17 +33,23 @@ object Rating extends Enumeration {
  *	@param quote_src the source of the quote (also supports Markdown)
  *	@param entries a list of updates to this statement
  *	@param latestEntry date when latest entry was written
- *	@param tags a list of tags
+ *	@param tagSet a set of tags for this statement
  *	@param rating the current rating
  *	@param rated time of last rating
- *	@param merged_id id of another [[Statement]] this statement is linked to
+ *	@param merged_id id of another this statement is linked to
  */
 case class Statement(id: Long, title: String, author: Author, category: Category,
 	quote: Option[String], quote_src: Option[String],
 	entries: List[Entry], latestEntry: Option[Date],
-	tags: Set[Tag],
+	tagSet: Set[Tag],
 	rating: Option[Rating], rated: Option[Date],
-	merged_id: Option[Long])
+	merged_id: Option[Long]) {
+
+  /**
+   * @return the statements [[Tag Tags]] ordered by [[Tag.name name]]
+   */
+  def tags: List[Tag] = tagSet.toList.sortBy(_.name)
+}
 
 object Statement {
 	def all(): Map[Author, List[Statement]] = {
@@ -171,7 +177,7 @@ object Statement {
 
 	def create(implicit connection: java.sql.Connection, title: String, author: Author, cat: Category, quote: Option[String], quote_src: Option[String], rating: Option[Rating], merged_id: Option[Long]): Statement = {
     if(author.rated) {
-      val message: String = "a statement with rated author must be rated and and not merged"
+      val message: String = "a statement with rated author must be rated and and not linked"
 
       require(rating.isDefined && merged_id.isEmpty, message)
     }

--- a/app/models/Statement.scala
+++ b/app/models/Statement.scala
@@ -15,14 +15,14 @@ object Rating extends Enumeration {
 }
 
 /** A statement, e.g. a campaign promise, that can be rated. <br/>
- *	
+ *
  * '''Invariants'''
  *
- *  1. If `author.rated`, `rating` must be set and `merged_id` must not be set. 
+ *  1. If `author.rated`, `rating` must be set and `merged_id` must not be set.
  *	   [[Author]]s form a hierarchy with a single rated Author on top. Statements
- *	   belonging to subordinate (non-rated) Authors may link to the statements of 
+ *	   belonging to subordinate (non-rated) Authors may link to the statements of
  *	   the single rated Author.
- *  1. If `!author.rated`, `rating` or `merged_id` may be set. If `rating` is set, 
+ *  1. If `!author.rated`, `rating` or `merged_id` may be set. If `rating` is set,
  *	   this rating will be displayed by all views. Otherwise, if `merged_id` is set,
  *	   the rating of the [[Statement]] referred to by `merged_id` will be displayed.
  *
@@ -36,7 +36,7 @@ object Rating extends Enumeration {
  *	@param tags a list of tags
  *	@param rating the current rating
  *	@param rated time of last rating
- *	@param merged_id id of another [[Statement]] this statement is linked to 
+ *	@param merged_id id of another [[Statement]] this statement is linked to
  */
 case class Statement(id: Long, title: String, author: Author, category: Category,
 	quote: Option[String], quote_src: Option[String],
@@ -170,8 +170,11 @@ object Statement {
 	}
 
 	def create(implicit connection: java.sql.Connection, title: String, author: Author, cat: Category, quote: Option[String], quote_src: Option[String], rating: Option[Rating], merged_id: Option[Long]): Statement = {
+    if(author.rated) {
+      val message: String = "a statement with rated author must be rated and and not merged"
 
-    if(author.rated) require(rating.isDefined && merged_id.isEmpty)
+      require(rating.isDefined && merged_id.isEmpty, message)
+    }
 
 		require(author.rated || merged_id.isDefined || !rating.isDefined)
 

--- a/app/models/Statement.scala
+++ b/app/models/Statement.scala
@@ -41,7 +41,7 @@ object Rating extends Enumeration {
 case class Statement(id: Long, title: String, author: Author, category: Category,
 	quote: Option[String], quote_src: Option[String],
 	entries: List[Entry], latestEntry: Option[Date],
-	tags: List[Tag],
+	tags: Set[Tag],
 	rating: Option[Rating], rated: Option[Date],
 	merged_id: Option[Long])
 
@@ -193,7 +193,7 @@ object Statement {
 				'rated -> rated,
 				'merged_id -> merged_id).executeUpdate()
 
-		Statement(id, title, author, cat, quote, quote_src, List[Entry](), None, List[Tag](), rating, rated, merged_id)
+		Statement(id, title, author, cat, quote, quote_src, List[Entry](), None, Set[Tag](), rating, rated, merged_id)
 	}
 
 	def edit(implicit connection: java.sql.Connection, id: Long, title: String, cat: Category, quote: Option[String], quote_src: Option[String], rating: Option[Rating], merged_id: Option[Long]) {
@@ -323,7 +323,7 @@ object Statement {
 					quote, quote_src,
 					List[Entry](),
 					latestEntry,
-					(tag_id, tag_name, tag_important).zipped.map( (id, name, important) => Tag(id, name, important) ).toList.sortBy(_.name),
+					(tag_id, tag_name, tag_important).zipped.map( (id, name, important) => Tag(id, name, important) ).toSet,
 					(if(merged_id.isDefined && !rating.isDefined) merged_rating else rating) map { r => if (0 <= r && r < Rating.maxId) Rating(r) else Rating.Unrated },
 					(if(merged_id.isDefined && !rating.isDefined) merged_rated else rated),
 					merged_id

--- a/app/models/Tag.scala
+++ b/app/models/Tag.scala
@@ -51,9 +51,13 @@ object Tag {
 			SQL("select id, name, important from tag order by name").as(tag*)
 	}
 
-	def add(stmt_id: Long, tag: Tag) {
+	def add(stmt_id: Long, tag: Tag): Unit = {
 		DB.withConnection{ implicit c => add(c, stmt_id, tag) }
 	}
+
+  def add(stmt_id: Long, tags: Tag*): Unit = {
+    tags.foreach(tag => add(stmt_id, tag))
+  }
 
 	def add(implicit connection: java.sql.Connection, stmt_id: Long, tag: Tag) {
 			SQL("insert into statement_tags values ({tag_id}, {stmt_id})").on(

--- a/test/controllers/ImportSpec.scala
+++ b/test/controllers/ImportSpec.scala
@@ -91,7 +91,7 @@ class ImportSpec extends Specification with WithTestDatabase {
         (ostmtNew.get.latestEntry must beNone) and
         (ostmtNew.get.merged_id must beNone) and
         (ostmtNew.get.category.name must beEqualTo(categoryNew)) and
-        (ostmtNew.get.tags.map(_.name).sorted.intersect(tagNew.sorted) must beEqualTo(tagNew.sorted))
+        (ostmtNew.get.tags.map(_.name) must containAllOf(tagNew))
     }
   }
 }

--- a/test/controllers/ImportSpec.scala
+++ b/test/controllers/ImportSpec.scala
@@ -22,7 +22,7 @@ class ImportSpec extends Specification with WithTestDatabase {
     override def before: Any = {
       User.create("test@test.net", "Tester", "secret", Role.Admin)
 
-      Author.create("Coalition Treaty", 1, true, "#ffffff", "#999999")
+      Author.create("Coalition Treaty", 1, false, "#ffffff", "#999999")
     }
   }
 

--- a/test/helpers/DateFactory.scala
+++ b/test/helpers/DateFactory.scala
@@ -1,0 +1,38 @@
+package helpers
+
+import java.util.{Date, Calendar}
+
+/**
+ * Helper object to create [[Date]] instances via a nice syntax in test cases.
+ *
+ * = Example =
+ *
+ * {{{
+ *  // 14th march 2014
+ *  val myDate: Date = 2014 \ 03 \ 14
+ * }}}
+ */
+
+object DateFactory {
+  case class Year(year: Int) {
+    def \(month: Int) = YearMonth(year, month)
+  }
+
+  case class YearMonth(year: Int, month: Int) {
+    def \(day: Int) = YearMonthDay(year, month, day)
+  }
+
+  case class YearMonthDay(year: Int, month: Int, day: Int)
+
+  implicit def int2Year(year: Int): Year = Year(year)
+
+  implicit def yearMonthDay2Date(ymd: YearMonthDay): Date = {
+    val calendar = Calendar.getInstance()
+
+    calendar.set(Calendar.YEAR, ymd.year)
+    calendar.set(Calendar.MONTH, ymd.month)
+    calendar.set(Calendar.DAY_OF_MONTH, ymd.day)
+
+    calendar.getTime
+  }
+}

--- a/test/models/StatementSpec.scala
+++ b/test/models/StatementSpec.scala
@@ -78,6 +78,20 @@ class StatementSpec extends Specification with WithTestDatabase {
     "return None when given invalid id" in {
       Statement.load(4123) must beNone
     }
+
+    // see issue #9: Tags shown several times when Statement has multiple entries
+    "not have multiple tags" in new TestStatements {
+      val tag1 = Tag.create("some tag")
+      Tag.add(statementA.id, tag1)
+
+      val entry1 = Entry.create(statementA.id, "some content", 2014 \ 4 \ 1, userA.id)
+      val entry2 = Entry.create(statementA.id, "some content", 2014 \ 4 \ 1, userA.id)
+      val entry3 = Entry.create(statementA.id, "some content", 2014 \ 4 \ 1, userA.id)
+
+      val Some(loadedStatement) = Statement.load(statementA.id)
+
+      loadedStatement.tags must haveSize(1)
+    }
   }
 
   "loadAll" should {

--- a/test/models/StatementSpec.scala
+++ b/test/models/StatementSpec.scala
@@ -10,6 +10,25 @@ import org.specs2.specification.Scope
 
 class StatementSpec extends Specification with WithTestDatabase {
 
+  "create" should {
+    "throw exception when creating unrated statement from rated author" in {
+      val ratedAuthor = Author.create("rated author", 1, true, "#000000", "#ffffff")
+      val category = Category.create("some category", 1)
+
+      Statement.create("title", ratedAuthor, category, None, None, None, None) must throwA[IllegalArgumentException]
+    }
+
+    "throw exception when creating merged statement from rated author" in {
+      val ratedAuthor = Author.create("rated author", 1, true, "#000000", "#ffffff")
+      val category = Category.create("some category", 1)
+      val statement = Statement.create("title", ratedAuthor, category, None, None, Some(Rating.InTheWorks), None)
+
+      {
+        Statement.create("title", ratedAuthor, category, None, None, Some(Rating.InTheWorks), Some(statement.id))
+      } must throwA[IllegalArgumentException]
+    }
+  }
+
   trait TestStatements extends Scope {
     val userA = User.create("user.a@test.de", "user a", "secret", Role.Editor)
 


### PR DESCRIPTION
`Statement.create` throws `IllegalArgumentException` when invalid statement is created by rated author.

To fix issue #9 I replaced the `List` for tags by a `Set`. This also eases dealing with tags since their order is no longer important.
