### PR TITLE
update tests to work with recent changes in RelatedUrl.loadRecent

### DIFF
--- a/test/models/RelatedUrlSpec.scala
+++ b/test/models/RelatedUrlSpec.scala
@@ -49,14 +49,19 @@ class RelatedUrlSpec  extends Specification with WithTestDatabase {
 
   "loadRecent" should {
     "return all urls in a date range" in new RelatedUrls {
+      val yesterday = new Date(new Date().getTime() - 24 * 60 * 60 * 1000) // now minus 1 day
+
       val url3 = RelatedUrl.create(statementA.id, "The most rercent", "http://someurl.com", 9.6, new Date(), RelatedCategory.Article)
-      RelatedUrl.loadRecent(1, None).map(_.id) must beEqualTo( List(url3.id) )
+      RelatedUrl.loadRecent(yesterday, None).map(_.id) must beEqualTo( List(url3.id) )
     }
 
     "return a limited number of urls in a date range" in new RelatedUrls {
       val url3 = RelatedUrl.create(statementA.id, "The most rercent", "http://someurl.com", 9.6, new Date(), RelatedCategory.Article)
+
+      val fromDate = new Date()
       val url4 = RelatedUrl.create(statementA.id, "The most rercent", "http://someurl.com", 11, new Date(), RelatedCategory.Article)
-      RelatedUrl.loadRecent(1, Some(1)).map(_.id) must beEqualTo( List(url4.id) )
+
+      RelatedUrl.loadRecent(fromDate, Some(new Date())).map(_.id) must beEqualTo( List(url4.id) )
     }
   }
 


### PR DESCRIPTION
@stheophil did I get this right or do the tests pass because of some obscure random fact now? :smile: 
